### PR TITLE
Improve efficiency of the dedupOptPIC stage in bpipe_dna.stage

### DIFF
--- a/bpipe_dna.stages
+++ b/bpipe_dna.stages
@@ -167,13 +167,17 @@ dedupOptPIC = {
 	OUTPUT=/dev/stdout
 	REMOVE_SEQUENCING_DUPLICATES=true
 	CREATE_INDEX=false
+	ADD_PG_TAG_TO_READS=false
+	CLEAR_DT=false
+	COMPRESSION_LEVEL=0
 	METRICS_FILE=${output.bam.prefix}_metrics.txt  |  $PICARD RevertSam
                                                                 INPUT=/dev/stdin
                                                                 OUTPUT=$output.bam
                                                                 CREATE_INDEX=true
                                                                 SORT_ORDER=coordinate
                                                                 REMOVE_DUPLICATE_INFORMATION=true
-                                                                REMOVE_ALIGNMENT_INFORMATION=false"""
+                                                                REMOVE_ALIGNMENT_INFORMATION=false
+								RESTORE_ORIGINAL_QUALITIES=false"""
 }
 
 dedupUmiPIC = {


### PR DESCRIPTION
- Add the option ADD_PG_TAG_TO_READS=false. It's not necessary to have 
the PG tag added to every read -> speed gain and reduced file size.
- Add the option CLEAR_DT=false. Original bam files don't have DT tags, 
so this step is unnecessary.
- Add the option COMPRESSION_LEVEL=0. The output of the first command is 
the direct input for the second, so avoiding compression of the inter-
mediate output improves speed.
- Add the option RESTORE_ORIGINAL_QUALITIES=false. At this stage no base 
quality score recalibration has been applied to the bam files, so there 
is nothing to restore.